### PR TITLE
srec2bin: fix overflow

### DIFF
--- a/srec2bin.c
+++ b/srec2bin.c
@@ -286,7 +286,7 @@ void binRecEnd(void)
           printf("[RecEnd  ] CheckSum[0x%08X] Length[%4d] Length[0x%X] RecEnd[0x%08lX]\n",
                 CheckSum, RecLength, RecLength, RecEnd);
 
-    fseek( fOut, -(RecLength), SEEK_CUR);  // move back Start Of Data
+    fseek( fOut, -((long) RecLength), SEEK_CUR);  // move back Start Of Data
 
     dumpfTell("Data   ", -1);
 


### PR DESCRIPTION
There is an overflow causing adam2app.bin to be 4294967304 (4Go!).

This patch fixes that and restores the size of adam2app.bin to 140.
Found on OpenWRT's version of the tool which doesn't have this issue:

```
http://git.openwrt.org/?p=openwrt.git;a=blob;f=tools/firmware-utils/src/srec2bin.c
```
